### PR TITLE
Doc and Template Fix

### DIFF
--- a/lib/mix/tasks/init.ex
+++ b/lib/mix/tasks/init.ex
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.Rivet.Init do
 
     Create your first model with:
 
-       mix rivet model {name}
+       mix rivet.new model {name}
     """)
   end
 end

--- a/lib/rivet/mix/templates.ex
+++ b/lib/rivet/mix/templates.ex
@@ -10,7 +10,7 @@ defmodule Rivet.Mix.Templates do
     use TypedEctoSchema
     use Rivet.Ecto.Model
 
-    typed_schema "<%= @c_table %>s" do
+    typed_schema "<%= @c_table %>" do
       #belongs_to(:user, ..., type: :binary_id, foreign_key: :user_id)
       #field(:type, Enum)
       timestamps()


### PR DESCRIPTION
I messed with rivet a little bit and found a few things:

after mix rivet.init:
Changed
```
Create your first model with:

   mix rivet model {name}
```
to
```
Create your first model with:

   mix rivet.new model {name}
```
To be accurate.


rivet/mix/templates.ex 
```Line #13 typed_schema "<%= @c_table %>s" do```
This causes a duplicate 's' as `c_table` is defined with one already `c_table: "#{table}s"`,
