### PR TITLE
Polish up migrations.

### DIFF
--- a/lib/mix/tasks/migrate.ex
+++ b/lib/mix/tasks/migrate.ex
@@ -26,7 +26,7 @@ defmodule Mix.Tasks.Rivet.Migrate do
 
   @defaults [
     all: true,
-    log: false,
+    log: :info,
     log_migrations_sql: false,
     log_migrator_sql: false
   ]

--- a/lib/rivet/cli/templates.ex
+++ b/lib/rivet/cli/templates.ex
@@ -45,7 +45,7 @@ defmodule Rivet.Cli.Templates do
   def migration(opts), do: migration_template(opts)
 
   embed_template(:migration, """
-  defmodule <%= @c_base %>.Migrations.<%= @c_name %> do
+  defmodule <%= @c_mod %>.Migrations.<%= @c_name %> do
     @moduledoc false
     use Ecto.Migration
 

--- a/lib/rivet/ecto/collection/model.ex
+++ b/lib/rivet/ecto/collection/model.ex
@@ -53,7 +53,6 @@ defmodule Rivet.Ecto.Collection.Model do
 
       defoverridable build: 1
 
-
       def changeset(item, attrs) do
         item
         |> cast(attrs, @update_allowed_fields)


### PR DESCRIPTION
Keeps the alias in the index.exs file, puts the entries in the same keyword order so they are easier to scan, and removes the extraneous `Elixir.` in the migration file itself. Now logs migrations run the way Ecto does.