### PR TITLE
Allow `limits` to specify multiple valid values.

### DIFF
--- a/lib/rivet/loader/index.ex
+++ b/lib/rivet/loader/index.ex
@@ -171,6 +171,12 @@ defmodule Rivet.Loader do
   true
   iex> match_limits?(%State{limits: %{env: ["red", "white", "blue"]}}, %{env: ["red", "blue"]})
   true
+  iex> match_limits?(%State{limits: %{env: ["red", "white", "blue"]}}, %{})
+  true
+  iex> match_limits?(%State{limits: %{env: ["red", "white", "blue"]}}, %{env: "purple"})
+  false
+  iex> match_limits?(%State{limits: %{env: ["red", "white", "blue"]}}, %{env: ["green"]})
+  false
   """
   def match_limits?(%State{limits: nil}, _), do: true
 

--- a/lib/rivet/loader/index.ex
+++ b/lib/rivet/loader/index.ex
@@ -167,6 +167,10 @@ defmodule Rivet.Loader do
   false
   iex> match_limits?(%State{limits: %{env: "red"}}, %{env: ["narf", "red"]})
   true
+  iex> match_limits?(%State{limits: %{env: ["red", "white", "blue"]}}, %{env: "red"})
+  true
+  iex> match_limits?(%State{limits: %{env: ["red", "white", "blue"]}}, %{env: ["red", "blue"]})
+  true
   """
   def match_limits?(%State{limits: nil}, _), do: true
 
@@ -182,7 +186,11 @@ defmodule Rivet.Loader do
             end
 
           val ->
-            val == req
+            if is_list(req) do
+              val in req
+            else
+              val == req
+            end
         end
         |> if do
           {:cont, true}

--- a/lib/rivet/loader/index.ex
+++ b/lib/rivet/loader/index.ex
@@ -174,8 +174,15 @@ defmodule Rivet.Loader do
     Enum.reduce_while(limits, true, fn {key, req}, _ ->
       if is_map_key(map, key) do
         case map[key] do
-          val when is_list(val) -> req in val
-          val -> val == req
+          val when is_list(val) ->
+            if is_list(req) do
+              Enum.any?(req, &(&1 in val))
+            else
+              req in val
+            end
+
+          val ->
+            val == req
         end
         |> if do
           {:cont, true}


### PR DESCRIPTION
We might allow multiple values for a key, while the file only specifies one.