### PR TITLE
Allow Mix tasks from Umbrella project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,9 @@ Look in module docs lib/mix/tasks/index.ex for command syntax
 
 ## TODO
 
-* running from within umbrella is hairy. Just run commands from within the sub-app, instead of top of umbrella, for now
 * configurable table prefixes in db schema
 * maturing command set (see mix rivet help)
 * tighter integration w/Ecto (see prior)
-* mix rivet migrate is silent, need to get it noisy like typical ecto.migrate
 * tests are currently going into path/model/model_test; should just be path/model_test
 * default model shouldn't create so many things
 

--- a/lib/mix/tasks/migrate.ex
+++ b/lib/mix/tasks/migrate.ex
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Rivet.Migrate do
     migrator = &Ecto.Migrator.run/4
 
     app =
-      case Mix.Project.config()[:app] do
+      case Application.get_env(:rivet, :app) do
         nil ->
           Mix.raise("""
           Could not find app; is this run from an umbrella? Rivet migrate must run


### PR DESCRIPTION
Get :app from config, not Mix project. Non-umbrellas can continue to use `def application()` in mix.exs, but umbrellas should just use the config/config.exs to set the same keys.

```
import Config

config :rivet, app: :core
```