### PR TITLE
If id and name are provided, change the name.

### DIFF
--- a/lib/rivet/loader/index.ex
+++ b/lib/rivet/loader/index.ex
@@ -123,15 +123,15 @@ defmodule Rivet.Loader do
       {module, :create, 1} ->
         state = debug(state, "=> MODEL #{inspect(module)}")
 
-        name =
+        claims =
           case data do
             %{id: id} -> [id: id]
             %{name: name} -> [name: name]
-            %{label: label} -> [name: label]
+            %{label: label} -> [label: label]
             _ -> []
           end
 
-        with {:ok, _, state} <- upsert_record(state, module, data, name), do: {:ok, state}
+        with {:ok, _, state} <- upsert_record(state, module, data, claims), do: {:ok, state}
     end
   end
 

--- a/lib/rivet/loader/index.ex
+++ b/lib/rivet/loader/index.ex
@@ -125,6 +125,7 @@ defmodule Rivet.Loader do
 
         name =
           case data do
+            %{id: id} -> [id: id]
             %{name: name} -> [name: name]
             %{label: label} -> [name: label]
             _ -> []


### PR DESCRIPTION
Rivet.Loader assumes `name` is a unique key, which isn't always true. `id` should be, however, so if it is given, lookup by that ID for upsert purposes, even if `label` or `name` are provided.